### PR TITLE
Don't override minter role on update

### DIFF
--- a/tokens/src/main/java/com/iconloop/score/token/irc2/IRC2Mintable.java
+++ b/tokens/src/main/java/com/iconloop/score/token/irc2/IRC2Mintable.java
@@ -30,7 +30,9 @@ public abstract class IRC2Mintable extends IRC2Basic {
     public IRC2Mintable(String _name, String _symbol, int _decimals) {
         super(_name, _symbol, _decimals);
         // By default, set the minter role to the owner
-        minter.set(Context.getOwner());
+        if (minter.get() == null) {
+            minter.set(Context.getOwner());
+        }
     }
 
     /**


### PR DESCRIPTION
Right now, the minter role is overriden by Context.getCaller() when the contract is updated.
This commit fixes this issue.