### PR TITLE
Implement IRC31

### DIFF
--- a/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31.java
+++ b/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import java.math.BigInteger;
+
+import score.Address;
+import score.annotation.Optional;
+
+public interface IRC31 {
+
+    // ================================================
+    // External methods
+    // ================================================
+    /**
+     *  Returns the balance of the owner's tokens.
+     * 
+     *  @param _owner   The address of the token holder
+     *  @param _id      ID of the token
+     *  @return         The _owner's balance of the token type requested
+     */
+    BigInteger balanceOf(Address _owner, BigInteger _id);
+
+    /**
+     *  Returns the balance of multiple owner/id pairs.
+     * 
+     *  @param _owners  The addresses of the token holders
+     *  @param _ids     IDs of the tokens
+     *  @return         The list of balance (i.e. balance for each owner/id pair)
+     */
+    BigInteger[] balanceOfBatch(Address[] _owners, BigInteger[] _ids);
+
+    /**
+     *  Returns an URI for a given token ID.
+     * 
+     *  @param _id  ID of the token
+     *  @return     The URI string
+     */
+    String tokenURI(BigInteger _id);
+
+    /**
+     *  Transfers {@code _value} amount of an token {@code _id} from one address to another address,
+     *  and must emit {@code TransferSingle} event to reflect the balance change.
+     * 
+     *  When the transfer is complete, this method must invoke {@code onIRC31Received} in {@code _to},
+     *  if {@code _to} is a contract. If the {@code onIRC31Received} method is not implemented in {@code _to} (receiver contract),
+     *  then the transaction must fail and the transfer of tokens should not occur.
+     *  If {@code _to} is an externally owned address, then the transaction must be sent without trying to execute
+     *  {@code onIRC31Received} in {@code _to}.
+     * 
+     *  Additional {@code _data} can be attached to this token transaction, and it should be sent unaltered in call
+     *  to {@code onIRC31Received} in {@code _to}. {@code _data} can be empty.
+     * 
+     *  Throws unless the caller is the current token holder or the approved address for the token ID.
+     *  Throws if {@code _from} does not have enough amount to transfer for the token ID.
+     *  Throws if {@code _to} is the zero address.
+     * 
+     *  @param _from   Source address
+     *  @param _to     Target address
+     *  @param _id     ID of the token
+     *  @param _value  The amount of transfer
+     *  @param _data   Additional data that should be sent unaltered in call to {@code _to}
+     */
+    void transferFrom(Address _from, Address _to, BigInteger _id, BigInteger _value, @Optional byte[] _data);
+
+    /**
+     *  Transfers {@code _values} amount(s) of token(s) {@code _ids} from one address to another address,
+     *  and must emit {@code TransferSingle} or {@code TransferBatch} event(s) to reflect all the balance changes.
+     * 
+     *  When all the transfers are complete, this method must invoke {@code onIRC31Received} or
+     *  {@code onIRC31BatchReceived(Address,Address,int[],int[],bytes)} in {@code _to},
+     *  if {@code _to} is a contract. If the {@code onIRC31Received} method is not implemented in {@code _to} (receiver contract),
+     *  then the transaction must fail and the transfers of tokens should not occur.
+     * 
+     *  If {@code _to} is an externally owned address, then the transaction must be sent without trying to execute
+     *  {@code onIRC31Received} in {@code _to}.
+     * 
+     *  Additional {@code _data} can be attached to this token transaction, and it should be sent unaltered in call
+     *  to {@code onIRC31Received} in {@code _to}. {@code _data} can be empty.
+     * 
+     *  Throws unless the caller is the current token holder or the approved address for the token IDs.
+     *  Throws if length of {@code _ids} is not the same as length of {@code _values}.
+     *  Throws if {@code _from} does not have enough amount to transfer for any of the token IDs.
+     *  Throws if {@code _to} is the zero address.
+     * 
+     *  @param _from    Source address
+     *  @param _to      Target address
+     *  @param _ids     IDs of the tokens (order and length must match {@code _values} list)
+     *  @param _values  Transfer amounts per token (order and length must match {@code _ids} list)
+     *  @param _data    Additional data that should be sent unaltered in call to {@code _to}
+     */
+    void transferFromBatch(Address _from, Address _to, BigInteger[] _ids, BigInteger[] _values, @Optional byte[] _data);
+
+    /**
+     * Enables or disables approval for a third party ("operator") to manage all of the caller's tokens,
+     * and must emit {@code ApprovalForAll} event on success.
+     * 
+     * @param _operator    Address to add to the set of authorized operators
+     * @param _approved    True if the operator is approved, false to revoke approval
+     */
+    void setApprovalForAll(Address _operator, boolean _approved);
+
+    /**
+     *  Returns the approval status of an operator for a given owner.
+     * 
+     *  @param _owner       The owner of the tokens
+     *  @param _operator    The address of authorized operator
+     *  @return             True if the operator is approved, false otherwise
+     */
+    boolean isApprovedForAll(Address _owner, Address _operator);
+    
+    // ================================================
+    // Event Logs
+    // ================================================
+    /**
+     *   Must trigger on any successful token transfers, including zero value transfers as well as minting or burning.
+     *   When minting/creating tokens, the {@code _from} must be set to zero address.
+     *   When burning/destroying tokens, the {@code _to} must be set to zero address.
+     * 
+     *   @param _operator  The address of an account/contract that is approved to make the transfer
+     *   @param _from      The address of the token holder whose balance is decreased
+     *   @param _to        The address of the recipient whose balance is increased
+     *   @param _id        ID of the token
+     *   @param _value     The amount of transfer
+     */
+    public void TransferSingle(Address _operator, Address _from, Address _to, BigInteger _id, BigInteger _value);
+    
+    /**
+     *  Must trigger on any successful token transfers, including zero value transfers as well as minting or burning.
+     *  When minting/creating tokens, the {@code _from} must be set to zero address.
+     *  When burning/destroying tokens, the {@code _to} must be set to zero address.
+     * 
+     *  @param _operator  The address of an account/contract that is approved to make the transfer
+     *  @param _from      The address of the token holder whose balance is decreased
+     *  @param _to        The address of the recipient whose balance is increased
+     *  @param _ids       Serialized bytes of list for token IDs (order and length must match {@code _values})
+     *  @param _values    Serialized bytes of list for transfer amounts per token (order and length must match {@code _ids})
+     * 
+     *  NOTE: RLP (Recursive Length Prefix) would be used for the serialized bytes to represent list type.
+     */
+    public void TransferBatch(Address _operator, Address _from, Address _to, byte[] _ids, byte[] _values);
+    
+    /**
+     *  Must trigger on any successful approval (either enabled or disabled) for a third party/operator address
+     *  to manage all tokens for the {@code _owner} address.
+     * 
+     *  @param _owner       The address of the token holder
+     *  @param _operator    The address of authorized operator
+     *  @param _approved    True if the operator is approved, false to revoke approval
+     */
+    public void ApprovalForAll(Address _owner, Address _operator, boolean _approved);
+    
+    /**
+     *  Must trigger on any successful URI updates for a token ID.
+     *  URIs are defined in RFC 3986.
+     *  The URI must point to a JSON file that conforms to the "ERC-1155 Metadata URI JSON Schema".
+     * 
+     *  @param _id     ID of the token
+     *  @param _value  The updated URI string
+     */
+    public void URI(BigInteger _id, String _value);
+
+}

--- a/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31Basic.java
+++ b/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31Basic.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import java.math.BigInteger;
+
+import score.Address;
+import score.BranchDB;
+import score.ByteArrayObjectWriter;
+import score.Context;
+import score.DictDB;
+import score.annotation.EventLog;
+import score.annotation.External;
+import score.annotation.Optional;
+
+public class IRC31Basic {
+
+    // ================================================
+    // Consts
+    // ================================================
+    public static final Address ZERO_ADDRESS = new Address(new byte[Address.LENGTH]);
+    
+    // ================================================
+    // SCORE DB 
+    // ================================================
+    // id => (owner => balance)
+    protected final BranchDB<BigInteger, DictDB<Address, BigInteger>> balances = Context.newBranchDB("balances", BigInteger.class);
+    // owner => (operator => approved)
+    protected final BranchDB<Address, DictDB<Address, Boolean>> operatorApproval = Context.newBranchDB("approval", Boolean.class);
+    // id => token URI
+    protected final DictDB<BigInteger, String> tokenURIs = Context.newDictDB("token_uri", String.class);
+
+    // ================================================
+    // Event Logs
+    // ================================================
+    /**
+     *   Must trigger on any successful token transfers, including zero value transfers as well as minting or burning.
+     *   When minting/creating tokens, the {@code _from} must be set to zero address.
+     *   When burning/destroying tokens, the {@code _to} must be set to zero address.
+     * 
+     *   @param _operator  The address of an account/contract that is approved to make the transfer
+     *   @param _from      The address of the token holder whose balance is decreased
+     *   @param _to        The address of the recipient whose balance is increased
+     *   @param _id        ID of the token
+     *   @param _value     The amount of transfer
+     */
+    @EventLog(indexed=3)
+    public void TransferSingle(Address _operator, Address _from, Address _to, BigInteger _id, BigInteger _value) {}
+    
+    /**
+     *  Must trigger on any successful token transfers, including zero value transfers as well as minting or burning.
+     *  When minting/creating tokens, the {@code _from} must be set to zero address.
+     *  When burning/destroying tokens, the {@code _to} must be set to zero address.
+     * 
+     *  @param _operator  The address of an account/contract that is approved to make the transfer
+     *  @param _from      The address of the token holder whose balance is decreased
+     *  @param _to        The address of the recipient whose balance is increased
+     *  @param _ids       Serialized bytes of list for token IDs (order and length must match {@code _values})
+     *  @param _values    Serialized bytes of list for transfer amounts per token (order and length must match {@code _ids})
+     * 
+     *  NOTE: RLP (Recursive Length Prefix) would be used for the serialized bytes to represent list type.
+     */
+    @EventLog(indexed=3)
+    public void TransferBatch(Address _operator, Address _from, Address _to, byte[] _ids, byte[] _values) {}
+    
+    /**
+     *  Must trigger on any successful approval (either enabled or disabled) for a third party/operator address
+     *  to manage all tokens for the {@code _owner} address.
+     * 
+     *  @param _owner       The address of the token holder
+     *  @param _operator    The address of authorized operator
+     *  @param _approved    True if the operator is approved, false to revoke approval
+     */
+    @EventLog(indexed=2)
+    public void ApprovalForAll(Address _owner, Address _operator, boolean _approved) {}
+    
+    /**
+     *  Must trigger on any successful URI updates for a token ID.
+     *  URIs are defined in RFC 3986.
+     *  The URI must point to a JSON file that conforms to the "ERC-1155 Metadata URI JSON Schema".
+     * 
+     *  @param _id     ID of the token
+     *  @param _value  The updated URI string
+     */
+    @EventLog(indexed=1)
+    public void URI(BigInteger _id, String _value) {}
+
+    // ================================================
+    // Internal methods
+    // ================================================
+    protected void _setTokenURI(BigInteger _id, String _uri) {
+        Context.require (_uri.length() > 0, 
+            "Uri should be set");
+        tokenURIs.set(_id, _uri);
+        this.URI(_id, _uri);
+    }
+
+    // ================================================
+    // External methods
+    // ================================================
+    /**
+     *  Returns the balance of the owner's tokens.
+     * 
+     *  @param _owner   The address of the token holder
+     *  @param _id      ID of the token
+     *  @return         The _owner's balance of the token type requested
+     */
+    @External(readonly = true)
+    public BigInteger balanceOf(Address _owner, BigInteger _id) {
+        return balances.at(_id).getOrDefault(_owner, BigInteger.ZERO);
+    }
+    
+    /**
+     *  Returns the balance of multiple owner/id pairs.
+     * 
+     *  @param _owners  The addresses of the token holders
+     *  @param _ids     IDs of the tokens
+     *  @return         The list of balance (i.e. balance for each owner/id pair)
+     */
+    @External(readonly = true)
+    public BigInteger[] balanceOfBatch(Address[] _owners, BigInteger[] _ids) {
+        Context.require(_owners.length == _ids.length, 
+            "_owners array size must match with _ids array size");
+
+        BigInteger[] balances = new BigInteger[_owners.length];
+
+        for (int i = 0; i < _owners.length; i++) {
+            balances[i] = balanceOf(_owners[i], _ids[i]);
+        }
+
+        return balances;
+    }
+
+    /**
+     *  Returns an URI for a given token ID.
+     * 
+     *  @param _id  ID of the token
+     *  @return     The URI string
+     */
+    @External(readonly = true)
+    public String tokenURI(BigInteger _id) {
+        return tokenURIs.get(_id);
+    }
+
+    /**
+     *  Transfers {@code _value} amount of an token {@code _id} from one address to another address,
+     *  and must emit {@code TransferSingle} event to reflect the balance change.
+     * 
+     *  When the transfer is complete, this method must invoke {@code onIRC31Received} in {@code _to},
+     *  if {@code _to} is a contract. If the {@code onIRC31Received} method is not implemented in {@code _to} (receiver contract),
+     *  then the transaction must fail and the transfer of tokens should not occur.
+     *  If {@code _to} is an externally owned address, then the transaction must be sent without trying to execute
+     *  {@code onIRC31Received} in {@code _to}.
+     * 
+     *  Additional {@code _data} can be attached to this token transaction, and it should be sent unaltered in call
+     *  to {@code onIRC31Received} in {@code _to}. {@code _data} can be empty.
+     * 
+     *  Throws unless the caller is the current token holder or the approved address for the token ID.
+     *  Throws if {@code _from} does not have enough amount to transfer for the token ID.
+     *  Throws if {@code _to} is the zero address.
+     * 
+     *  @param _from   Source address
+     *  @param _to     Target address
+     *  @param _id     ID of the token
+     *  @param _value  The amount of transfer
+     *  @param _data   Additional data that should be sent unaltered in call to {@code _to}
+     */
+    @External
+    public void transferFrom(Address _from, Address _to, BigInteger _id, BigInteger _value, @Optional byte[] _data) {
+        final Address caller = Context.getCaller();
+
+        Context.require(!_to.equals(ZERO_ADDRESS), 
+            "_to must be non-zero");
+        Context.require(_from.equals(caller) || this.isApprovedForAll(_from, caller), 
+            "Need operator approval for 3rd party transfers");
+        Context.require(BigInteger.ZERO.compareTo(_value) <= 0 && _value.compareTo(balanceOf(_from, _id)) <= 0, 
+            "Insufficient funds");
+
+        // Transfer funds
+        DictDB<Address, BigInteger> balance = balances.at(_id);
+        balance.set(_from, balanceOf(_from, _id).subtract(_value));
+        balance.set(_to,   balanceOf(_to,   _id).add     (_value));
+
+        // Emit event
+        this.TransferSingle(caller, _from, _to, _id, _value);
+
+        if (_to.isContract()) {
+            // Call {@code onIRC31Received} if the recipient is a contract
+            Context.call(_to, "onIRC31Received", caller, _from, _id, _value, _data == null ? new byte[]{} : _data);
+        }
+    }
+
+    /**
+     * Convert a list of BigInteger to a RLP-encoded byte array
+     * 
+     * @param list A list of BigInteger
+     * @return a RLP encoded byte array
+     */
+    protected static byte[] rlpEncode(BigInteger[] ids) {
+        Context.require(ids != null);
+
+        ByteArrayObjectWriter writer = Context.newByteArrayObjectWriter("RLPn");
+
+        writer.beginList(ids.length);
+        for (BigInteger v : ids) {
+            writer.write(v);
+        }
+        writer.end();
+
+        return writer.toByteArray();
+    }
+
+    /**
+     *  Transfers {@code _values} amount(s) of token(s) {@code _ids} from one address to another address,
+     *  and must emit {@code TransferSingle} or {@code TransferBatch} event(s) to reflect all the balance changes.
+     * 
+     *  When all the transfers are complete, this method must invoke {@code onIRC31Received} or
+     *  {@code onIRC31BatchReceived(Address,Address,int[],int[],bytes)} in {@code _to},
+     *  if {@code _to} is a contract. If the {@code onIRC31Received} method is not implemented in {@code _to} (receiver contract),
+     *  then the transaction must fail and the transfers of tokens should not occur.
+     * 
+     *  If {@code _to} is an externally owned address, then the transaction must be sent without trying to execute
+     *  {@code onIRC31Received} in {@code _to}.
+     * 
+     *  Additional {@code _data} can be attached to this token transaction, and it should be sent unaltered in call
+     *  to {@code onIRC31Received} in {@code _to}. {@code _data} can be empty.
+     * 
+     *  Throws unless the caller is the current token holder or the approved address for the token IDs.
+     *  Throws if length of {@code _ids} is not the same as length of {@code _values}.
+     *  Throws if {@code _from} does not have enough amount to transfer for any of the token IDs.
+     *  Throws if {@code _to} is the zero address.
+     * 
+     *  @param _from    Source address
+     *  @param _to      Target address
+     *  @param _ids     IDs of the tokens (order and length must match {@code _values} list)
+     *  @param _values  Transfer amounts per token (order and length must match {@code _ids} list)
+     *  @param _data    Additional data that should be sent unaltered in call to {@code _to}
+     */
+    @External
+    public void transferFromBatch(Address _from, Address _to, BigInteger[] _ids, BigInteger[] _values, @Optional byte[] _data) {
+        final Address caller = Context.getCaller();
+
+        Context.require(!_to.equals(ZERO_ADDRESS),
+            "_to must be non-zero");
+        Context.require(_ids.length == _values.length, 
+            "id/value pairs mismatch");
+        Context.require(_from.equals(caller) || this.isApprovedForAll(_from, caller), 
+            "Need operator approval for 3rd party transfers");
+        
+        for (int i = 0; i < _ids.length; i++) {
+            BigInteger _id = _ids[i];
+            BigInteger _value = _values[i];
+            
+            Context.require(_value.compareTo(BigInteger.ZERO) >= 0, 
+                "Insufficient funds");
+
+            BigInteger balanceFrom = balanceOf(_from, _id);
+            
+            Context.require(_value.compareTo(balanceFrom) <= 0, 
+                "Insufficient funds");
+
+            // Transfer funds
+            BigInteger balanceTo = balanceOf(_to, _id);
+            DictDB<Address, BigInteger> balance = balances.at(_id);
+            balance.set(_from, balanceFrom.subtract(_value));
+            balance.set(_to, balanceTo.add (_value));
+        }
+
+        // Emit event
+        this.TransferBatch(caller, _from, _to, rlpEncode(_ids), rlpEncode(_values));
+        
+        if (_to.isContract()) {
+            // call {@code onIRC31BatchReceived} if the recipient is a contract
+            Context.call(_to, "onIRC31BatchReceived", 
+                caller, _from, _ids, _values, _data == null ? new byte[]{} : _data);
+        }
+    }
+
+    /**
+     * Enables or disables approval for a third party ("operator") to manage all of the caller's tokens,
+     * and must emit {@code ApprovalForAll} event on success.
+     * 
+     * @param _operator    Address to add to the set of authorized operators
+     * @param _approved    True if the operator is approved, false to revoke approval
+     */
+    @External
+    public void setApprovalForAll(Address _operator, boolean _approved) {
+        final Address caller = Context.getCaller();
+
+        operatorApproval.at(caller).set(_operator, _approved);
+        this.ApprovalForAll(caller, _operator, _approved);
+    }
+
+    /**
+     *  Returns the approval status of an operator for a given owner.
+     * 
+     *  @param _owner       The owner of the tokens
+     *  @param _operator    The address of authorized operator
+     *  @return             True if the operator is approved, false otherwise
+     */
+    @External(readonly = true)
+    public boolean isApprovedForAll(Address _owner, Address _operator) {
+        return operatorApproval.at(_owner).getOrDefault(_operator, false);
+    }
+}

--- a/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31MintBurn.java
+++ b/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31MintBurn.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import java.math.BigInteger;
+
+import score.Address;
+import score.Context;
+import score.DictDB;
+
+public class IRC31MintBurn extends IRC31Basic {
+
+    // ================================================
+    // SCORE DB 
+    // ================================================
+    // id ==> creator
+    protected final DictDB<BigInteger, Address> creators = Context.newDictDB("creators", Address.class);
+
+    // ================================================
+    // External methods
+    // ================================================
+    /**
+     *  Creates a new token type and assigns _supply to creator
+     * 
+     *  @param _owner   Owner address of the tokens
+     *  @param _id      ID of the token
+     *  @param _supply  The initial token supply
+     *  @param _uri     The token URI
+     */
+    protected void _mint (Address _owner, BigInteger _id, BigInteger _supply, String _uri) {
+        Context.require (creators.get(_id) == null,
+            "Token is already minted");
+        Context.require (_supply.compareTo(BigInteger.ZERO) > 0,
+            "Supply should be positive");
+        Context.require (_uri.length() > 0,
+            "Uri should be set");
+
+        creators.set(_id, _owner);
+        balances.at(_id).set(_owner, _supply);
+
+        // emit transfer event for Mint semantic
+        this.TransferSingle(_owner, ZERO_ADDRESS, _owner, _id, _supply);
+
+        // set token URI and emit event
+        this._setTokenURI(_id, _uri);
+    }
+
+    /**
+     *  Creates a new token type and assigns _supply to caller
+     * 
+     *  @param _id      ID of the token
+     *  @param _supply  The initial token supply
+     *  @param _uri     The token URI
+     */
+    protected void _mint (BigInteger _id, BigInteger _supply, String _uri) {
+        _mint(Context.getCaller(), _id, _supply, _uri);
+    }
+
+    /**
+     *  Destroys tokens for a given amount
+     * 
+     *  @param _id      ID of the token
+     *  @param _amount  The amount of tokens to burn
+     */
+    protected void _burn (BigInteger _id, BigInteger _amount) {
+        Context.require (creators.get(_id) != null, 
+            "Invalid token id");
+        Context.require (_amount.compareTo(BigInteger.ZERO) > 0, 
+            "Amount should be positive");
+
+        final Address caller = Context.getCaller();
+        
+        BigInteger balance = balanceOf(caller, _id);
+
+        Context.require(BigInteger.ZERO.compareTo(_amount) <= 0 && _amount.compareTo(balance) <= 0, 
+            "Not an owner or invalid amount");
+
+        balances.at(_id).set(caller, balance.subtract(_amount));
+
+        // emit transfer event for Burn semantic
+        this.TransferSingle(caller, caller, ZERO_ADDRESS, _id, _amount);
+    }
+
+    /**
+     *  Updates the given token URI
+     * 
+     *  @param _id      ID of the token
+     *  @param _uri     The token URI
+     */
+    protected void _setTokenURI (BigInteger _id, String _uri) {
+        Context.require (creators.get(_id).equals(Context.getCaller()), 
+            "Not token creator");
+        
+        super._setTokenURI(_id, _uri);
+    }
+}

--- a/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31Receiver.java
+++ b/tokens/src/main/java/com/iconloop/score/token/irc31/IRC31Receiver.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 ICON Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import score.Address;
+import score.Context;
+import score.DictDB;
+import score.annotation.EventLog;
+import score.annotation.External;
+import score.annotation.Optional;
+
+import java.math.BigInteger;
+
+/**
+ * Smart contracts that want to receive tokens from IRC31-compatible token contracts must implement all of the following receiver methods to accept transfers.
+ */
+public class IRC31Receiver {
+
+    // ================================================
+    // SCORE DB 
+    // ================================================
+    // allowlist of token contracts
+    final private DictDB<Address, Boolean> originators = Context.newDictDB("originators", Boolean.class);
+
+    // ================================================
+    // Event Logs
+    // ================================================
+    @EventLog(indexed=3)
+    public void IRC31Received(
+        Address _origin,  
+        Address _operator, 
+        Address _from, 
+        BigInteger _id, 
+        BigInteger _value, 
+        byte[] _data) {}
+
+    // ================================================
+    // External methods
+    // ================================================
+    @External
+    public void setOriginator (Address _origin, boolean _approved) {
+        Context.require(Context.getOwner().equals(Context.getCaller()),
+            "Not contract owner");
+        Context.require(_origin.isContract(),
+            "Not contract address");
+        originators.set(_origin, _approved);
+    }
+
+    @External
+    public void onIRC31Received(Address _operator, Address _from, BigInteger _id, BigInteger _value, @Optional byte[] _data) {
+        /*
+            A method for handling a single token type transfer, which is called from the multi token contract.
+            It works by analogy with the fallback method of the normal transactions and returns nothing.
+            
+            Throws if it rejects the transfer.
+            @param _operator  The address which initiated the transfer
+            @param _from      The address which previously owned the token
+            @param _id        The ID of the token being transferred
+            @param _value     The amount of tokens being transferred
+            @param _data      Additional data with no specified format
+        */
+        final Address caller = Context.getCaller();
+        Context.require(originators.get(caller) != null,
+            "Unrecognized token contract");
+        this.IRC31Received(caller, _operator, _from, _id, _value, _data);
+    }
+
+    @External
+    public void onIRC31BatchReceived(Address _operator, Address _from, BigInteger[] _ids, BigInteger[] _values, @Optional byte[] _data) {
+        /*
+            A method for handling multiple token type transfers, which is called from the multi token contract.
+            It works by analogy with the fallback method of the normal transactions and returns nothing.
+            
+            Throws if it rejects the transfer.
+            @param _operator  The address which initiated the transfer
+            @param _from      The address which previously owned the token
+            @param _ids       The list of IDs of each token being transferred (order and length must match `_values` list)
+            @param _values    The list of amounts of each token being transferred (order and length must match `_ids` list)
+            @param _data      Additional data with no specified format
+        */
+        final Address caller = Context.getCaller();
+        Context.require(originators.get(caller) != null,
+            "Unrecognized token contract");
+
+        for (int i = 0; i < _ids.length; i++) {
+            BigInteger _id = _ids[i];
+            BigInteger _value = _values[i];
+            this.IRC31Received(caller, _operator, _from, _id, _value, _data);
+        }
+    }}

--- a/tokens/src/test/java/com/iconloop/score/token/irc31/IRC31MinBurnToken.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc31/IRC31MinBurnToken.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import java.math.BigInteger;
+
+import score.annotation.External;
+
+public class IRC31MinBurnToken extends IRC31MintBurn {
+    
+    @External(readonly = true)
+    public String name () {
+        return "SampleMultiToken";
+    }
+
+    @External
+    public void mint(BigInteger _id, BigInteger _supply, String _uri) {
+        super._mint(_id, _supply, _uri);
+    }
+
+    @External
+    public void burn(BigInteger _id, BigInteger _amount) {
+        super._burn(_id, _amount);
+    }
+    
+    @External
+    public void setTokenURI (BigInteger _id, String _uri) {
+        super._setTokenURI(_id, _uri);
+    }
+}

--- a/tokens/src/test/java/com/iconloop/score/token/irc31/MetadataTest.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc31/MetadataTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import score.Address;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigInteger;
+
+public class MetadataTest extends MultiTokenTest {
+    
+  @BeforeEach
+  void setup() throws Exception {
+    token_setup();
+    reset(spy);
+}
+
+@Test
+void testTransferSingle() {
+    BigInteger supply = BigInteger.valueOf(100);
+
+    BigInteger newId = mint_token(supply);
+    /*
+        @EventLog(indexed=3)
+        public void TransferSingle(
+            Address _operator, 
+            Address _from, 
+            Address _to, 
+            Integer _id, 
+            BigInteger _value) {}
+    */
+    ArgumentCaptor<Address> operator = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<Address> from = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<Address> to = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<BigInteger> id = ArgumentCaptor.forClass(BigInteger.class);
+    ArgumentCaptor<BigInteger> value = ArgumentCaptor.forClass(BigInteger.class);
+
+    verify(spy).TransferSingle(
+        operator.capture(),
+        from.capture(),
+        to.capture(),
+        id.capture(),
+        value.capture());
+    
+    // Check TransferSingle event
+    assertTrue(operator.getValue().equals(owner.getAddress()));
+    assertTrue(from.getValue().equals(IRC31Basic.ZERO_ADDRESS));
+    assertTrue(to.getValue().equals(owner.getAddress()));
+    assertTrue(id.getValue() == newId);
+    assertTrue(value.getValue().equals(supply));
+  }
+
+  @Test
+  void testTokenURI() {
+    BigInteger supply = BigInteger.valueOf(100);
+    BigInteger newId = mint_token(supply);
+    String uri = (String) score.call("tokenURI", newId);
+    String expectedUri = "https://craft.network/" + newId;
+    assertTrue(uri.equals(expectedUri));
+  }
+
+  @Test
+  void testSetTokenURI() {
+    BigInteger supply = BigInteger.valueOf(100);
+    BigInteger newId = mint_token(supply);
+    reset(spy);
+
+    String newURI = ((String) score.call("tokenURI", newId)) + "_updated";
+    score.invoke(owner, "setTokenURI", newId, newURI);
+
+    // Test event
+    /*
+        @EventLog(indexed=1)
+        public void URI(
+            Integer _id, 
+            String _value) {}
+    */
+    ArgumentCaptor<BigInteger> id = ArgumentCaptor.forClass(BigInteger.class);
+    ArgumentCaptor<String> value = ArgumentCaptor.forClass(String.class);
+    verify(spy).URI(id.capture(), value.capture());
+
+    assertEquals(id.getValue(), newId);
+    assertEquals(value.getValue(), newURI);
+
+    // Check updated URI
+    assertEquals(score.call("tokenURI", newId), newURI);
+  }
+
+  @Test
+  void testSetTokenURIOnlyOwner() {
+    BigInteger supply = BigInteger.valueOf(100);
+    BigInteger newId = mint_token(supply);
+    reset(spy);
+
+    String newURI = ((String) score.call("tokenURI", newId)) + "_updated";
+    assertThrows(AssertionError.class, () -> 
+        score.invoke(eve, "setTokenURI", newId, newURI));
+  }
+}

--- a/tokens/src/test/java/com/iconloop/score/token/irc31/MintBurnTest.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc31/MintBurnTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.iconloop.score.token.irc31;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.reset;
+
+import java.math.BigInteger;
+
+import com.iconloop.score.test.Account;
+
+public class MintBurnTest extends MultiTokenTest {
+    
+  @BeforeEach
+  void setup() throws Exception {
+    token_setup();
+    reset(spy);
+  }
+
+  void check_balance (Account account, BigInteger id, BigInteger amount)
+  {
+    BigInteger balance = (BigInteger) score.call("balanceOf", account.getAddress(), id);
+    assertEquals(amount, balance);
+  }
+
+  @Test
+  void testMint() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 1));
+    BigInteger newId = mint_token(supply);
+    check_balance(owner, newId, supply);
+  }
+
+  @Test
+  void testMintAlreadyExists() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 1));
+    BigInteger newId = mint_token(supply);
+
+    // mint with the existing id
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "mint", newId, supply, "uri"));
+  }
+
+  @Test
+  void testBurnInvalidToken() {
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "burn", getTokenId(), BigInteger.ONE));
+  }
+
+  @Test
+  void testBurn() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 2));
+    BigInteger newId = mint_token(supply);
+
+    // burn with creator
+    BigInteger burn_amount = BigInteger.ONE;
+    score.invoke(owner, "burn", newId, burn_amount);
+  }
+
+  @Test
+  void testBurnAllSupply() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 2));
+    BigInteger newId = mint_token(supply);
+
+    BigInteger burn_amount = supply;
+    score.invoke(owner, "burn", newId, burn_amount);
+  }
+
+  @Test
+  void testBurnTooMuch() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 2));
+    BigInteger newId = mint_token(supply);
+
+    // burn with creator
+    BigInteger burn_amount = supply.add(BigInteger.ONE);
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "burn", newId, burn_amount));
+  }
+
+  @Test
+  void testBurnNotOwner() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 2));
+    BigInteger newId = mint_token(supply);
+
+    // burn with eve
+    BigInteger burn_amount = BigInteger.ONE;
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(eve, "burn", newId, burn_amount));
+  }
+
+  @Test
+  void testBurnAfterTransferOwnership() {
+    BigInteger supply = BigInteger.valueOf((int) (Math.random() * 100 + 2));
+    BigInteger newId = mint_token(supply);
+
+    // transfer ownership 
+    score.invoke(owner, "transferFrom", 
+      owner.getAddress(), 
+      alice.getAddress(), 
+      newId, 
+      supply,
+      "test".getBytes());
+
+    check_balance(owner, newId, BigInteger.ZERO);
+    check_balance(alice, newId, supply);
+    
+    // burn with new owner
+    BigInteger burn_amount = BigInteger.ONE;
+    score.invoke(alice, "burn", newId, burn_amount);
+    check_balance(alice, newId, supply.subtract(burn_amount));
+    check_balance(owner, newId, BigInteger.ZERO);
+  }
+
+}

--- a/tokens/src/test/java/com/iconloop/score/token/irc31/MultiTokenTest.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc31/MultiTokenTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.iconloop.score.token.irc31;
+
+import static org.mockito.Mockito.spy;
+
+import java.math.BigInteger;
+
+import com.iconloop.score.test.Account;
+import com.iconloop.score.test.Score;
+import com.iconloop.score.test.ServiceManager;
+import com.iconloop.score.test.TestBase;
+
+public class MultiTokenTest extends TestBase {
+    
+    protected static final ServiceManager sm = getServiceManager();
+    protected static final Account owner = sm.createAccount();
+    protected static final Account minter = sm.createAccount();
+    protected static final Account burner = sm.createAccount();
+    protected static final Account alice = sm.createAccount();
+    protected static final Account bob = sm.createAccount();
+    protected static final Account eve = sm.createAccount();
+    protected static final BigInteger EXA = BigInteger.TEN.pow(18);
+
+    protected static Score score;
+    protected static IRC31MinBurnToken spy;
+    
+    void token_setup () throws Exception {
+        score = sm.deploy(owner, IRC31MinBurnToken.class);
+        spy = (IRC31MinBurnToken) spy(score.getInstance());
+        score.setInstance(spy);
+    }
+    
+    BigInteger mint_token (BigInteger supply) {
+        return mint_token (supply, owner);
+    }
+
+    BigInteger mint_token (BigInteger supply, Account account) {
+        BigInteger newId = getTokenId();
+        String uri = "https://craft.network/" + newId;
+        score.invoke(owner, "mint", newId, supply, uri);
+        return newId;
+    }
+    
+    BigInteger getTokenId () {
+        return BigInteger.valueOf((int) (Math.random() * 1000000));
+    }
+}

--- a/tokens/src/test/java/com/iconloop/score/token/irc31/ReceiverTest.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc31/ReceiverTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iconloop.score.token.irc31;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigInteger;
+
+import com.iconloop.score.test.Account;
+import com.iconloop.score.test.Score;
+import com.iconloop.score.test.ServiceManager;
+import com.iconloop.score.test.TestBase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import score.Address;
+
+public class ReceiverTest extends TestBase {
+    
+    protected static final ServiceManager sm = getServiceManager();
+    protected static final Account owner = sm.createAccount();
+    protected static final Account minter = sm.createAccount();
+    protected static final Account burner = sm.createAccount();
+    protected static final Account alice = sm.createAccount();
+    protected static final Account bob = sm.createAccount();
+    protected static final Account eve = sm.createAccount();
+    protected static final BigInteger EXA = BigInteger.TEN.pow(18);
+
+    protected static Score scoreRcv;
+    protected static IRC31Receiver spyRcv;
+
+    protected static Score scoreToken;
+    protected static IRC31MinBurnToken spyToken;
+    
+    void receiver_setup () throws Exception {
+        scoreRcv = sm.deploy(owner, IRC31Receiver.class);
+        spyRcv = (IRC31Receiver) spy(scoreRcv.getInstance());
+        scoreRcv.setInstance(spyRcv);
+    }
+
+    void token_setup () throws Exception {
+      scoreToken = sm.deploy(owner, IRC31MinBurnToken.class);
+      spyToken = (IRC31MinBurnToken) spy(scoreToken.getInstance());
+      scoreToken.setInstance(spyToken);
+    }
+  
+    BigInteger mint_token (BigInteger supply) {
+      BigInteger newId = getTokenId();
+      String uri = "https://craft.network/" + newId;
+      scoreToken.invoke(owner, "mint", newId, supply, uri);
+      return newId;
+    }
+
+    BigInteger getTokenId () {
+        return BigInteger.valueOf((int) (Math.random() * 1000000));
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+      receiver_setup();
+      token_setup();
+      reset(spyRcv);
+      reset(spyToken);
+    }
+    
+    @Test
+    void testSetOriginator() {
+      scoreRcv.invoke(owner, "setOriginator", scoreToken.getAddress(), true);
+    }
+    
+    @Test
+    void testSetOriginatorNotOwner() {
+      assertThrows(AssertionError.class, () -> 
+        scoreRcv.invoke(eve, "setOriginator", scoreToken.getAddress(), true));
+    }
+    
+    @Test
+    void testSetOriginatorInvalidContractAddress() {
+      assertThrows(AssertionError.class, () -> 
+        scoreRcv.invoke(owner, "setOriginator", alice.getAddress(), true));
+    }
+    
+    @Test
+    void testOnReceived() throws Exception {
+
+      BigInteger supply = BigInteger.valueOf(100);
+      BigInteger newSupply = supply.divide(BigInteger.TWO);
+      BigInteger newId = mint_token(supply);
+      reset(spyToken);
+
+      byte[] data = "Hello".getBytes();
+
+      scoreRcv.invoke(owner, "setOriginator", scoreToken.getAddress(), true);
+
+      scoreToken.invoke(owner, "transferFrom", 
+        owner.getAddress(), 
+        scoreRcv.getAddress(), 
+        newId, 
+        newSupply,
+        data);
+        
+      /*
+        @EventLog(indexed=3)
+        public void TransferSingle(
+            Address _operator, 
+            Address _from, 
+            Address _to, 
+            Integer _id, 
+            BigInteger _value) {}
+      */
+      ArgumentCaptor<Address> operator = ArgumentCaptor.forClass(Address.class);
+      ArgumentCaptor<Address> from = ArgumentCaptor.forClass(Address.class);
+      ArgumentCaptor<Address> to = ArgumentCaptor.forClass(Address.class);
+      ArgumentCaptor<BigInteger> id = ArgumentCaptor.forClass(BigInteger.class);
+      ArgumentCaptor<BigInteger> value = ArgumentCaptor.forClass(BigInteger.class);
+
+      verify(spyToken).TransferSingle(
+          operator.capture(),
+          from.capture(),
+          to.capture(),
+          id.capture(),
+          value.capture());
+      
+      // Check TransferSingle event
+      assertEquals(operator.getValue(), owner.getAddress());
+      assertEquals(from.getValue(), owner.getAddress());
+      assertEquals(to.getValue(), scoreRcv.getAddress());
+      assertEquals(id.getValue(), newId);
+      assertEquals(value.getValue(), newSupply);
+
+      /*
+        @EventLog(indexed=3)
+        public void IRC31Received(
+            Address _origin,  
+            Address _operator, 
+            Address _from, 
+            Integer _id, 
+            BigInteger _value, 
+            byte[] _data) {}
+      */
+      ArgumentCaptor<Address> origin = ArgumentCaptor.forClass(Address.class);
+      ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+
+      verify(spyRcv).IRC31Received(
+          origin.capture(),
+          operator.capture(),
+          from.capture(),
+          id.capture(),
+          value.capture(),
+          dataCaptor.capture());
+      
+      // Check IRC31Received event
+      assertEquals(origin.getValue(), scoreToken.getAddress());
+      assertEquals(operator.getValue(), owner.getAddress());
+      assertEquals(from.getValue(), owner.getAddress());
+      assertEquals(id.getValue(), newId);
+      assertEquals(value.getValue(), newSupply);
+      assertEquals(dataCaptor.getValue(), data);
+    }
+  
+    @Test
+    void testOnBatchReceived() {
+      BigInteger supply = BigInteger.valueOf(100);
+      
+      BigInteger[] ids = new BigInteger[3];
+      for (int i = 0; i < ids.length; i++) {
+        ids[i] = mint_token(supply);
+      }
+
+      BigInteger[] values = {BigInteger.valueOf(50), BigInteger.valueOf(60), BigInteger.valueOf(70)};
+
+      scoreRcv.invoke(owner, "setOriginator", scoreToken.getAddress(), true);
+
+      scoreToken.invoke(owner, "transferFromBatch", 
+        owner.getAddress(), scoreRcv.getAddress(), ids, values, "test".getBytes());
+    }
+}

--- a/tokens/src/test/java/com/iconloop/score/token/irc31/TransferTest.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc31/TransferTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2021 ICONation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.iconloop.score.token.irc31;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import score.Address;
+import score.Context;
+import score.ObjectReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigInteger;
+
+public class TransferTest extends MultiTokenTest {
+    
+  @BeforeEach
+  void setup() throws Exception {
+    token_setup();
+    reset(spy);
+  }
+
+  
+  @Test
+  void testTransferFromZeroAddress() {
+    BigInteger supply = BigInteger.valueOf(100);
+    BigInteger newId = mint_token(supply, alice);
+
+    // transfer ownership 
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFrom", 
+        owner.getAddress(), 
+        IRC31Basic.ZERO_ADDRESS, 
+        newId, 
+        supply,
+        "test".getBytes()));
+  }
+
+  @Test
+  void testTransferFromTooMuch() {
+    BigInteger supply = BigInteger.valueOf(100);
+    BigInteger newId = mint_token(supply, alice);
+
+    // transfer ownership 
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFrom", 
+        owner.getAddress(), 
+        alice.getAddress(), 
+        newId, 
+        supply.add(BigInteger.ONE),
+        "test".getBytes()));
+  }
+
+  @Test
+  void testTransferFrom() {
+    BigInteger supply = BigInteger.valueOf(100);
+    BigInteger newId = mint_token(supply, alice);
+    reset(spy);
+    
+    // transfer ownership 
+    score.invoke(owner, "transferFrom", 
+      owner.getAddress(), 
+      alice.getAddress(), 
+      newId, 
+      supply,
+      "test".getBytes());
+
+    /*
+        @EventLog(indexed=3)
+        public void TransferSingle(
+            Address _operator, 
+            Address _from, 
+            Address _to, 
+            Integer _id, 
+            BigInteger _value) {}
+    */
+    ArgumentCaptor<Address> operator = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<Address> from = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<Address> to = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<BigInteger> id = ArgumentCaptor.forClass(BigInteger.class);
+    ArgumentCaptor<BigInteger> value = ArgumentCaptor.forClass(BigInteger.class);
+
+    verify(spy).TransferSingle(
+        operator.capture(),
+        from.capture(),
+        to.capture(),
+        id.capture(),
+        value.capture());
+    
+    // Check TransferSingle event
+    assertEquals(operator.getValue(), owner.getAddress());
+    assertEquals(from.getValue(), owner.getAddress());
+    assertEquals(to.getValue(), alice.getAddress());
+    assertEquals(id.getValue(), newId);
+    assertEquals(value.getValue(), supply);
+
+    // Balance check
+    assertEquals(BigInteger.ZERO, score.call("balanceOf", owner.getAddress(), newId));
+    assertEquals(supply,          score.call("balanceOf", alice.getAddress(), newId));
+
+    // fail case: alice => bob by owner
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFrom", 
+        alice.getAddress(), 
+        bob.getAddress(), 
+        newId, 
+        supply,
+        "test".getBytes()));
+      
+    // approve owner to transfer alice's token
+    score.invoke(alice, "setApprovalForAll", owner.getAddress(), true);
+
+    // success case: retry alice => bob by owner
+    score.invoke(owner, "transferFrom", 
+      alice.getAddress(), 
+      bob.getAddress(), 
+      newId, 
+      supply,
+      "test".getBytes());
+      
+    // Balance check
+    assertEquals(BigInteger.ZERO, score.call("balanceOf", owner.getAddress(), newId));
+    assertEquals(BigInteger.ZERO, score.call("balanceOf", alice.getAddress(), newId));
+    assertEquals(supply,          score.call("balanceOf", bob.getAddress(),   newId));
+  }
+
+  @Test
+  void transferFromBatch() {
+    BigInteger supply = BigInteger.valueOf(100);
+
+    BigInteger[] ids = new BigInteger[3];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = mint_token(supply);
+    }
+
+    BigInteger[] values = {BigInteger.valueOf(50), BigInteger.valueOf(60), BigInteger.valueOf(70)};
+    
+    score.invoke(owner, "transferFromBatch", owner.getAddress(), alice.getAddress(), ids, values, "test".getBytes());
+    
+    for (int i = 0; i < ids.length; i++) {
+      BigInteger balance = (BigInteger) score.call("balanceOf", alice.getAddress(), ids[i]);
+      assertEquals(values[i], balance);
+    }
+    
+    // fail case: alice => bob by owner
+    BigInteger[] values2 = {BigInteger.valueOf(10), BigInteger.valueOf(20), BigInteger.valueOf(30)};
+    
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFromBatch", alice.getAddress(), bob.getAddress(), ids, values2, "test".getBytes()));
+
+      
+    // approve owner to transfer alice's token
+    score.invoke(alice, "setApprovalForAll", owner.getAddress(), true);
+    
+    // success case: retry alice => bob by owner
+    score.invoke(owner, "transferFromBatch", alice.getAddress(), bob.getAddress(), ids, values2, "test".getBytes());
+
+    // check TransferBatch events
+    /*
+      @EventLog(indexed=3)
+      public void TransferBatch(
+        Address _operator, 
+        Address _from, 
+        Address _to, 
+        byte[] _ids, 
+        byte[] _values)
+    */
+    ArgumentCaptor<Address> operator = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<Address> from = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<Address> to = ArgumentCaptor.forClass(Address.class);
+    ArgumentCaptor<byte[]> idsCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<byte[]> valuesCaptor = ArgumentCaptor.forClass(byte[].class);
+
+    verify(spy, times(2)).TransferBatch(
+        operator.capture(),
+        from.capture(),
+        to.capture(),
+        idsCaptor.capture(),
+        valuesCaptor.capture());
+  
+    assertEquals(operator.getAllValues().get(0), owner.getAddress());
+    assertEquals(from.getAllValues().get(0),     owner.getAddress());
+    assertEquals(to.getAllValues().get(0),       alice.getAddress());
+
+    assertEquals(operator.getAllValues().get(1), owner.getAddress());
+    assertEquals(from.getAllValues().get(1),     alice.getAddress());
+    assertEquals(to.getAllValues().get(1),       bob.getAddress());
+    byte[] data0 = idsCaptor.getAllValues().get(1);
+    byte[] data1 = valuesCaptor.getAllValues().get(1);
+
+    ObjectReader reader = Context.newByteArrayObjectReader("RLPn", data0);
+    int sizeIds = reader.readInt();
+    BigInteger[] idsRlp = new BigInteger[sizeIds];
+
+    for (int i = 0; i < sizeIds; i++) {
+      idsRlp[i] = reader.readBigInteger();
+    }
+    
+    ObjectReader reader2 = Context.newByteArrayObjectReader("RLPn", data1);
+    int sizeValues = reader2.readInt();
+    BigInteger[] valuesRlp = new BigInteger[sizeValues];
+    for (int i = 0; i < sizeValues; i++) {
+      valuesRlp[i] = reader2.readBigInteger();
+    }
+
+    for (int i = 0; i < ids.length; i++) {
+      assertEquals(idsRlp[i], ids[i]);
+    }
+
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(valuesRlp[i], values2[i]);
+    }
+
+    // balanceBatch check
+    BigInteger[] exp = {BigInteger.valueOf(50), BigInteger.valueOf(40), BigInteger.valueOf(30)};
+    Address[] owners = {owner.getAddress(), alice.getAddress(), bob.getAddress()};
+    BigInteger[] balances = (BigInteger[]) score.call("balanceOfBatch", owners, ids);
+    for (int i = 0; i < balances.length; i++) {
+      assertEquals(exp[i], balances[i]);
+    }
+  }
+  
+  
+  @Test
+  void testTransferFromBatchZeroAddress() {
+    BigInteger supply = BigInteger.valueOf(100);
+
+    BigInteger[] ids = new BigInteger[3];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = mint_token(supply);
+    }
+
+    BigInteger[] values = {BigInteger.valueOf(50), BigInteger.valueOf(60), BigInteger.valueOf(70)};
+    
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFromBatch", owner.getAddress(), IRC31Basic.ZERO_ADDRESS, ids, values, "test".getBytes()));
+  }
+
+  @Test
+  void testTransferFromBatchIdValueMismatch() {
+    BigInteger supply = BigInteger.valueOf(100);
+
+    BigInteger[] ids = new BigInteger[3];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = mint_token(supply);
+    }
+
+    BigInteger[] values = {BigInteger.valueOf(50)};
+    
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFromBatch", owner.getAddress(), alice.getAddress(), ids, values, "test".getBytes()));
+  }
+
+  @Test
+  void testTransferFromBatchTooMuch() {
+    BigInteger supply = BigInteger.valueOf(100);
+
+    BigInteger[] ids = new BigInteger[3];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = mint_token(supply);
+    }
+
+    BigInteger[] values = {BigInteger.valueOf(50), supply.add(BigInteger.ONE), BigInteger.valueOf(70)};
+    
+    // transfer ownership 
+    assertThrows(AssertionError.class, () -> 
+      score.invoke(owner, "transferFromBatch", owner.getAddress(), alice.getAddress(), ids, values, "test".getBytes()));
+  }
+}


### PR DESCRIPTION
This pull request implements the whole specification of IIP-31 (icon-project/IIPs#31)

The Java code and tests stricly follow the same logic than the one in its Python alternative (https://github.com/sink772/multi-token-standard).

I also looked at @jspark-icon's PR (https://github.com/sink772/javaee-tokens/pull/6) and improved this PR based on it, mostly for RLP encoding. I noticed new useful methods but didn't implement `mintBatch` and `burnBatch` as they didn't match with the IIP-31.

There are 2 failing tests, `testOnBatchReceived` and `transferFromBatch` because `newByteArrayObjectWriter` isn't implemented yet in  `javaee-unittest `