### PR TITLE
Remove unused tokenId variable

### DIFF
--- a/tokens/src/test/java/com/iconloop/score/token/irc3/IRC3BasicTest.java
+++ b/tokens/src/test/java/com/iconloop/score/token/irc3/IRC3BasicTest.java
@@ -96,7 +96,7 @@ public class IRC3BasicTest extends TestBase {
 
     @Test
     void balanceOf() {
-        var tokenId = mintToken();
+        mintToken();
         assertEquals(1, tokenScore.call("balanceOf", owner.getAddress()));
     }
 


### PR DESCRIPTION
Minor fix but it triggers a warning in vscode java linter