### PR TITLE
Change _tokenExists visibility from private to protected

### DIFF
--- a/tokens/src/main/java/com/iconloop/score/token/irc3/IRC3Basic.java
+++ b/tokens/src/main/java/com/iconloop/score/token/irc3/IRC3Basic.java
@@ -158,7 +158,7 @@ public abstract class IRC3Basic implements IRC3 {
         Transfer(owner, ZERO_ADDRESS, tokenId);
     }
 
-    private boolean _tokenExists(BigInteger tokenId) {
+    protected boolean _tokenExists(BigInteger tokenId) {
         return tokenOwners.contains(tokenId);
     }
 


### PR DESCRIPTION
It is hard to check for existance of a token extending the current IRC3 implementation.
The only available solution for checking if a token exists is by calling `ownerOf` as it throws if the token doesn't exist.

This PR modifies the visibility of the `_tokenExists` in order to access it from a child class.